### PR TITLE
OBU to DSRC to CARMA Truck Mobility Operation Message Forwarding Issue

### DIFF
--- a/dsrc_driver/src/dsrc_client.cpp
+++ b/dsrc_driver/src/dsrc_client.cpp
@@ -146,6 +146,8 @@ void DSRCOBUClient::process(const std::shared_ptr<const std::vector<uint8_t>>& d
             len_bytes = 1;
             // check for 0 length
             if (len_byte_1 == 0x00) { continue; }
+            // check for 1 length
+            if (len_byte_1 == 0x01) { continue; }
         }
             // length < 16384 encoded by 14 bits in 2 bytes (10xxxxxx xxxxxxxx)
         else if ((len_byte_1 & 0x40) == 0x00) { //we know msb = 1, check that next bit is 0


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Fix large data size not being forwarded issue.
## Description
During the Truck Inspection Plugin integration testing by Dan using the Silver Truck and Tahoe, the message wasn't fully forwarded by the Tahoe's DSRC Driver to the Message Node.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/879

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration Testing in Vehicle
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
C++, logic change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
