### PR TITLE
(DO NOT MERGE) Update wave.json

### DIFF
--- a/dsrc_driver/etc/wave.json
+++ b/dsrc_driver/etc/wave.json
@@ -15,14 +15,14 @@
   },
   {
     "name" : "MAP",
-    "psid" : "0082",
+    "psid" : "8002",
     "dsrc_id" : "18",
     "channel" : "172",
     "priority" : "3"
   },
   {
     "name" : "SPAT",
-    "psid" : "0082",
+    "psid" : "8002",
     "dsrc_id" : "19",
     "channel" : "172",
     "priority" : "3"


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Change SPAT psid
## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1388
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
OBU was receiving the binary but it was not forwarding to CARMA. OBU script with this needed to be updated as well, which will be stored in every cars and vector sharepoint

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration Tested on Fusion
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
